### PR TITLE
Updated dependencies from PyProcar

### DIFF
--- a/vaspvis/band.py
+++ b/vaspvis/band.py
@@ -5,8 +5,8 @@ from pymatgen.symmetry.bandstructure import HighSymmKpath
 from pymatgen.core.periodic_table import Element
 from vaspvis.unfold import unfold, make_kpath, removeDuplicateKpoints
 from pymatgen.core.periodic_table import Element
-from pyprocar.utilsprocar import UtilsProcar
-from pyprocar.procarparser import ProcarParser
+from pyprocar.utils.utilsprocar import UtilsProcar
+from pyprocar.io.procarparser import ProcarParser
 from functools import reduce
 import matplotlib.pyplot as plt
 from matplotlib.patches import Wedge

--- a/vaspvis/utils.py
+++ b/vaspvis/utils.py
@@ -19,8 +19,8 @@ from ase.build import niggli_reduce, sort
 from ase.io import read, write
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.analysis.molecule_structure_comparator import CovalentRadius
-from pyprocar.utilsprocar import UtilsProcar
-from pyprocar.procarparser import ProcarParser
+from pyprocar.utils.utilsprocar import UtilsProcar
+from pyprocar.io.procarparser import ProcarParser
 import matplotlib.pyplot as plt
 from fastdtw import fastdtw
 import numpy as np


### PR DESCRIPTION
PyProcar parser has been moved to a `io` directory with https://github.com/romerogroup/pyprocar/commit/32f98e93a4e187800b4bd3171b8b8af864294d99

PyProcar utils has been moved to a `utils` folder in https://github.com/romerogroup/pyprocar/commit/a57f14cf92594651c117ec4d90ac7447d4aa9683#diff-40023bd2c44bf9bdc4403e5d0ea9e36701a6d3800ab0b1611fc7be6b80ce01d4